### PR TITLE
Sushi 0.6.0 vs fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _genonce.sh
 _updatePublisher.bat
 _updatePublisher.sh
 build/StructureDefinition*
+build/ValueSet*
 build/input/.DS_Store
 build/input/ignoreWarnings.txt
 

--- a/OncocoreVS.fsh
+++ b/OncocoreVS.fsh
@@ -38,19 +38,19 @@ Description: "Value set of human genetic variants, drawn from [ClinVar](https://
 ValueSet:     CancerBodyLocationVS
 Title: "Cancer Body Location Value Set"
 Description:  "Codes describing the location(s) of primary or secondary cancer. The value set includes all codes from the SNOMED CT body structure hierarchy (codes descending from 123037004 'Body Structure'). The cancer body location may also be expressed using ICD-O-3 topography codes, however, those codes are not included here due to intellectual property restrictions. No other code systems are considered conformant."
-* codes from system SCT where code is-a SCT#123037004  "Body Structure"
+* codes from system SCT where concept is-a #123037004  "Body Structure"
 
 ValueSet:   HistologyMorphologyBehaviorVS
 Title: "Histology Morphology Behavior Value Set"
 Description: "Codes representing the structure, arrangement, and behavioral characteristics of malignant neoplasms, and cancer cells. Inclusion criteria: in situ neoplasms and malignant neoplasms. Exclusion criteria: benign neoplasms and neoplasms of unspecified behavior. Note: As the vocabulary binding is extensible within this IG, ICD-O-3 morphology codes (including behavior suffix) may also be used; they are not included in the value set for intellectual property reasons. For primary cancers, the ICD-O-3 behavior suffix should be /1, /2, or /3. For secondary cancers, the ICD-O-3 behavior suffix should be /6. Only SNOMED CT and ICD-O-3 are considered conformant to the specification. However, to be compliant with US Core Profiles, ICD-O-3 may only be used if there is no suitable code in SNOMED CT."
-* codes from system SCT where code is-a SCT#367651003 "Malignant neoplasm of primary, secondary, or uncertain origin (morphologic abnormality)"
-* codes from system SCT where code is-a SCT#399919001 "Carcinoma in situ - category (morphologic abnormality)"
+* codes from system SCT where concept is-a #367651003 "Malignant neoplasm of primary, secondary, or uncertain origin (morphologic abnormality)"
+* codes from system SCT where concept is-a #399919001 "Carcinoma in situ - category (morphologic abnormality)"
 * codes from system SCT where
-    code is-a SCT#399983006 "In situ adenomatous neoplasm - category (morphologic abnormality)" and
-    code is-not-a SCT#399983006 "Papillary neoplasm, pancreatobiliary-type, with high grade intraepithelial neoplasia (morphologic abnormality)" and
-    code is-not-a SCT#128640002 "Glandular intraepithelial neoplasia, grade III (morphologic abnormality)" and
-    code is-not-a SCT#450890000 "Glandular intraepithelial neoplasia, low grade (morphologic abnormality)" and
-    code is-not-a SCT#703548001 "Endometrioid intraepithelial neoplasia (morphologic abnormality)"
+    concept is-a #399983006 "In situ adenomatous neoplasm - category (morphologic abnormality)" and
+    concept is-not-a #399983006 "Papillary neoplasm, pancreatobiliary-type, with high grade intraepithelial neoplasia (morphologic abnormality)" and
+    concept is-not-a #128640002 "Glandular intraepithelial neoplasia, grade III (morphologic abnormality)" and
+    concept is-not-a #450890000 "Glandular intraepithelial neoplasia, low grade (morphologic abnormality)" and
+    concept is-not-a #703548001 "Endometrioid intraepithelial neoplasia (morphologic abnormality)"
 * SCT#399878004 "Malignant neoplasm with pilar differentiation (morphologic abnormality)"
 
 ValueSet:   CancerHistologicGradeVS

--- a/build/input/ImplementationGuide-fhir.us.mcode.json
+++ b/build/input/ImplementationGuide-fhir.us.mcode.json
@@ -26,7 +26,7 @@
   ],
   "dependsOn": [
     {
-      "uri": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core-3.1.0",
+      "uri": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|3.1.0",
       "packageId": "hl7.fhir.us.core",
       "version": "3.1.0"
     }
@@ -392,6 +392,118 @@
         "name": "Tumor Marker",
         "description": "The result of a tumor marker test. Tumor marker tests are generally used to guide cancer treatment decisions and monitor treatment, as well as to predict the chance of recovery and cancer recurrence. A tumor marker is a substance found in tissue or blood or other body fluids that may be a sign of cancer or certain benign (non-cancer) conditions. Most tumor markers are made by both normal cells and cancer cells, but they are made in larger amounts by cancer cells. A tumor marker may help to diagnose cancer, plan treatment, or find out how well treatment is working or if cancer has come back. Examples of tumor markers include CA-125 (in ovarian cancer), CA 15-3 (in breast cancer), CEA (in colon cancer), and PSA (in prostate cancer). Tumor markers differ from genetic markers in that they are measured at the levels of the protein and substance post-RNA protein synthesis. (Definition adapted from: [NCI Dictionary of Cancer Terms](https://www.cancer.gov/publications/dictionaries/cancer-terms/def/tumor-marker-test) and [Cancer.Net](https://www.cancer.net/navigating-cancer-care/diagnosing-cancer/tests-and-procedures/tumor-marker-tests)). Implementation note: The data value for TumorMarkerTest has cardinality is 0..1 (required if known) because when the test result is indeterminate, no quantitative data value will be reported. Instead, the reason for the null value will be reported in the DataAbsentReason field.",
         "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/CancerBodyLocationVS"
+        },
+        "name": "Cancer Body Location Value Set",
+        "description": "Codes describing the location(s) of primary or secondary cancer. The value set includes all codes from the SNOMED CT body structure hierarchy (codes descending from 123037004 'Body Structure'). The cancer body location may also be expressed using ICD-O-3 topography codes, however, those codes are not included here due to intellectual property restrictions. No other code systems are considered conformant."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/CancerDiseaseStatusEvidenceTypeVS"
+        },
+        "name": "Cancer Disease Status Evidence Type Value Set",
+        "description": "The type of evidence backing up the clinical determination of cancer progression. The code 'SCT#252416005 Histopathology test (procedure)' is intended to be used when there is a biopsy that contributes evidence of the cancer disease status."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/CancerHistologicGradeVS"
+        },
+        "name": "Cancer Histologic Grade Value Set",
+        "description": "The grade of the tumor. This is a subset of the LOINC answer list LL213-0, which represents allowable values for NAACCR data item #440. The original answer list is outdated, as it includes terms pointing to the lineage of hematopoietic/lymphoid neoplasms, which have been retired by NAACCR as of version 18 Data Standards and Data Dictionary."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/CancerRelatedSurgicalProcedureVS"
+        },
+        "name": "Cancer-Related Surgical Procedure Value Set",
+        "description": "Includes selected SNOMED CT codes that may be used in the treatment of cancer tumors. Codes from ICD-10-PCS and CPT are acceptable. CPT codes are not listed here due to intellectual property restrictions. ICD-10-PCS codes are not listed because of a limitation in the FHIR Implementation Guide publisher. For CPT and ICD-10-PCS, only codes representing surgical procedures should be used. \n\nConformance note: If an ICD-10-PCS code is used, and a semantically equivalent SNOMED CT code is available, the resulting FHIR Procedure instance will not be compliant with [US Core Profiles](http://hl7.org/fhir/us/core/STU3/index.html)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/CancerStagingSystemVS"
+        },
+        "name": "Cancer Staging System Value Set",
+        "description": "System used for staging. Because SNOMED CT does not currently have a code representing AJCC Version 8, specify the exact text 'AJCC Version 8' in the text sub-field of the code structure, and omit the code."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/ClinVarVS"
+        },
+        "name": "ClinVar Value Set",
+        "description": "Value set of human genetic variants, drawn from [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/). The codes in this value set refer to the ClinVar Variation ID, or the identifier for the variant or set of variants that were interpreted. [Source: NCBI ClinVar Data Dictionary](https://www.ncbi.nlm.nih.gov/projects/clinvar/ClinVarDataDictionary.pdf)"
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/GeneticSpecimenTypeVS"
+        },
+        "name": "Genetic Specimen Type Value Set",
+        "description": "The type of specimen analyzed in a genetic test. The values are taken from code system http://terminology.hl7.org/CodeSystem/v2-0487, and represent a subset of HL7 Version 2 Table 0487 (http://hl7.org/fhir/v2/0487)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/GeneticTestVS"
+        },
+        "name": "Genetic Test Value Set",
+        "description": "Value set containing codes representing genetic tests. Currently the best source of codes is the [Genetic Test Registry](http://www.ncbi.nlm.nih.gov/gtr). The user should be aware that the GTR cannot be a sole reliable source since the test data is voluntarily updated and there is no overarching data steward. This value set contains all codes from http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes (namely, the subset of LOINC codes with CLASSTYPE = 1), plus all codes in GTR.\n\nImplementation note: Although only a subset of LOINC codes is formally part of this value set, the value set itself contains all codes in LOINC, because FHIR cannot create an implicitly-defined value set based on LOINC's CLASSTYPE property.\n\nConformance note: To be conformant to US Core, a LOINC code must be used, if available. Only if there is no suitable code in LOINC may other codes (such as those from GTR) be used."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/HistologyMorphologyBehaviorVS"
+        },
+        "name": "Histology Morphology Behavior Value Set",
+        "description": "Codes representing the structure, arrangement, and behavioral characteristics of malignant neoplasms, and cancer cells. Inclusion criteria: in situ neoplasms and malignant neoplasms. Exclusion criteria: benign neoplasms and neoplasms of unspecified behavior. Note: As the vocabulary binding is extensible within this IG, ICD-O-3 morphology codes (including behavior suffix) may also be used; they are not included in the value set for intellectual property reasons. For primary cancers, the ICD-O-3 behavior suffix should be /1, /2, or /3. For secondary cancers, the ICD-O-3 behavior suffix should be /6. Only SNOMED CT and ICD-O-3 are considered conformant to the specification. However, to be compliant with US Core Profiles, ICD-O-3 may only be used if there is no suitable code in SNOMED CT."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/SurgicalMarginInvolvementVS"
+        },
+        "name": "Surgical Margin Involvement Value Set",
+        "description": "Indication of whether the tumor was involved at the edge of resection."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/TNMDistantMetastasesCategoryVS"
+        },
+        "name": "TNM Distant Metastases Category Value Set",
+        "description": "This value set is intended to contain allowable values for the M category, according to TNM staging rules. SNOMED CT codes or AJCC codes (preferrably, version 8 for current cancers) are allowed, but are not listed here due to AJCC intellectual property restrictions.\n\n* AJCC terminology: examples of M categories include 'cM0', denoting there is no evidence of distant metastases, and 'pM1', an indication that the cancer has metasticized. The full set of allowable clinical and pathologic M categories, along with its current descriptions, can be accessed through the AJCC Staging Manual and any applicable updates and corrections, as well as the AJCC API.\n\n* SNOMED CT: The SNOMED CT US Edition has content related to the M category under the hierarchy of 385380006 'Metastasis category finding', such as 30893008 'M0 category' and 443841006 'pM1a category'. If using SNOMED CT to store M category findings, the use of codes that do not contain descriptions of the categories, such as the examples provided, is encouraged, as stage finding codes in SNOMED CT may not be up-to-date with current AJCC guidance. Note that SNOMED CT codes do not always make a distinction between clinical and pathological classifications (e.g. 'cM0' and 'pM0' may be represented by the same SNOMED CT code 30893008 'M0 category'). In addition, SNOMED CT may not have complete TNM staging terminology and may require supplementation with codes from another controlled vocabulary (e.g. NCI Thesaurus)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/TNMPrimaryTumorCategoryVS"
+        },
+        "name": "TNM Primary Tumor Category Value Set",
+        "description": "This value set is intended to contain allowable values for the T category, according to TNM staging rules. SNOMED CT codes or AJCC codes (preferrably, version 8 for current cancers) are allowed, but are not listed here due to AJCC intellectual property restrictions.\n\n* AJCC terminology: examples of T categories include 'cTX', used when the tumor primary tumor cannot be evaluated, 'pT0', denoting there is no evidence of a primary tumor, and 'pTis', referencing carcinoma in situ (with some cancer-specific exceptions). Other T categories refer to increasing size of the primary tumor. Please note allowable T categories may vary between clinical and pathologic classifications. The full set of allowable clinical and pathologic T categories, along with its current descriptions, can be accessed through the AJCC Staging Manual and any applicable updates and corrections, as well as the AJCC API.\n\n* SNOMED CT has content related to the T category under the hierarchy of 385356007 'Tumor stage finding', such as 23351008 'T1 category' and 261650005 'Tumor stage T1c'. If using SNOMED CT to store T category findings, the use of codes that do not contain descriptions of the categories, such as the examples provided, is encouraged, as stage finding codes in SNOMED CT may not be up-to-date with current AJCC guidance. Note that SNOMED CT codes do not always make a distinction between clinical and pathological classifications (e.g. cT1 and pT1 may be represented by the same SNOMED CT code 23351008 'T1 category'). In addition, SNOMED CT may not have complete TNM staging terminology and may require supplementation with codes from another controlled vocabulary (e.g. NCI Thesaurus)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/TNMRegionalNodesCategoryVS"
+        },
+        "name": "TNM Regional Nodes Category Value Set",
+        "description": "This value set is intended to contain allowable values for the N category, according to TNM staging rules. SNOMED CT codes or AJCC codes (preferrably, version 8 for current cancers) are allowed, but are not listed here due to AJCC intellectual property restrictions.\n\n* AJCC terminology: examples of N categories include 'cN0', indicating no evidence of lymph node involvement, and 'pN1', indicating regional lymph node involvement to a small extent, with specific thresholds for the lymph node groups and number of lymph nodes involved. Other N categories refer to increasing lymph node involvement. Please note allowable N categories may vary between clinical and pathologic classifications. The full set of allowable clinical and pathologic N categories, along with its current descriptions, can be accessed through the AJCC Staging Manual and any applicable updates and corrections, as well as the AJCC API.\n\n* SNOMED CT has content related to the N category under the hierarchy of 385382003 'Node category finding', such as 5856006 'N3 category' and 277672002 'Node stage N1a'. If using SNOMED CT to store N category findings, the use of codes that do not contain descriptions of the categories, such as the examples provided, is encouraged, as stage finding codes in SNOMED CT may not be up-to-date with current AJCC guidance. Note that SNOMED CT codes do not always make a distinction between clinical and pathological classifications (e.g. 'cN1' and 'pN1' may be represented by the same SNOMED CT code 53623008 'N1 category'). In addition, SNOMED CT may not have complete TNM staging terminology and may require supplementation with codes from another controlled vocabulary (e.g. NCI Thesaurus)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/TNMStageGroupVS"
+        },
+        "name": "TNM Stage Group Value Set",
+        "description": "This value set is intended to contain allowable values for Stage Group, according to TNM staging rules. SNOMED CT codes or AJCC codes (preferrably, version 8 for current cancers) are allowed, but are not listed here due to AJCC intellectual property restrictions.\n\n*AJCC terminology: examples of stage groups include 'Stage 0' and 'Stage IIA'. The full set of stage groups, as well rules on how to assign a stage group, can be accessed through the AJCC Staging Manual and any applicable updates and corrections, as well as the AJCC API.\n\n* SNOMED CT has content representing stage group under the hierarchy of 261612004 'Stages', such as 258215001 'Stage 1' and 261614003 'Stage2A'. In addition, SNOMED CT may not have complete TNM staging terminology and may require supplementation with codes from another controlled vocabulary (e.g. NCI Thesaurus)."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/TumorMarkerTestVS"
+        },
+        "name": "TumorMarkerTestVS",
+        "description": "Codes representing tests for tumor markers. This value set of LOINC codes is not comprehensive and can be extended. LOINC codes are preferred. Other vocabularies can be used only if the test of interest is not covered by LOINC.\n\nFHIR implementation note: At the current time, profiles for the specific LOINC tests mentioned here do not exist."
+      },
+      {
+        "reference": {
+          "reference": "ValueSet/YesNoUnknownVS"
+        },
+        "name": "YesNoUnknownVS",
+        "description": "A value set containing yes, no, and unknown."
       }
     ],
     "page": {

--- a/build/input/includes/menu.xml
+++ b/build/input/includes/menu.xml
@@ -11,7 +11,7 @@
   </li-->
   <li><a href="artifacts.html#2">Profiles</a></li>
   <li><a href="artifacts.html#3">Extensions</a></li>
-  <!--li><a href="artifacts.html#4">Value Sets</a></li-->
+  <li><a href="artifacts.html#4">Value Sets</a></li>
   <li><a href="downloads.html">Downloads</a></li>
   <li><a href="examples.html">Examples</a></li>
   <li><a href="http://hl7.org/fhir/us/mcode/history.html">History</a></li>


### PR DESCRIPTION
This PR fixes the definition of two value sets to uses `concept` instead of `code` in SCT filters.

It also adds the currently defined `ValueSet`s to the ImplementationGuide JSON and re-enables the menu item.

**THIS PR REQUIRES SUSHI 0.6.0**