### PR TITLE
Added TumorMarker and GeneticSpecimen example.

### DIFF
--- a/CancerCondition.fsh
+++ b/CancerCondition.fsh
@@ -97,7 +97,7 @@ Description:  "A comorbidity refers to one or more diseases or conditions that o
 
 
 
-// Tumor profile was in mCODE, but not primary (hidden). The way we have used the CancerConditionParent, it is not necessary to list Tumor explicitly in TumorMarkerTest and CancerDiseaseStatus. For example, we have `* focus only Reference(CancerConditionParent)` and not (in CIMPL) `Value only PrimaryCancerCondition or SecondaryCancerCondition or Tumor`
+// Tumor profile was in mCODE, but not primary (hidden). The way we have used the CancerConditionParent, it is not necessary to list Tumor explicitly in TumorMarker and CancerDiseaseStatus. For example, we have `* focus only Reference(CancerConditionParent)` and not (in CIMPL) `Value only PrimaryCancerCondition or SecondaryCancerCondition or Tumor`
 /*
 Profile: Tumor
 Parent: CancerConditionParent

--- a/CancerGenomics.fsh
+++ b/CancerGenomics.fsh
@@ -76,13 +76,13 @@ Description:    "Records an alteration in the most common DNA nucleotide sequenc
 // CG Reporting IG does not constrain the CytogeneticNomenclature value type.
 
 
-Profile:        TumorMarkerTest
+Profile:        TumorMarker
 Parent:         USCoreObservationLab
 Id:             TumorMarker
 Title:          "Tumor Marker"
 Description:    "The result of a tumor marker test. Tumor marker tests are generally used to guide cancer treatment decisions and monitor treatment, as well as to predict the chance of recovery and cancer recurrence. A tumor marker is a substance found in tissue or blood or other body fluids that may be a sign of cancer or certain benign (noncancer) conditions. Most tumor markers are made by both normal cells and cancer cells, but they are made in larger amounts by cancer cells. A tumor marker may help to diagnose cancer, plan treatment, or find out how well treatment is working or if cancer has come back. Examples of tumor markers include CA-125 (in ovarian cancer), CA 15-3 (in breast cancer), CEA (in colon cancer), and PSA (in prostate cancer). Tumor markers differ from genetic markers in that they are measured at the levels of the protein and substance post-RNA protein synthesis. (Definition adapted from: [NCI Dictionary of Cancer Terms](https://www.cancer.gov/publications/dictionaries/cancer-terms/def/tumor-marker-test) and [Cancer.Net](https://www.cancer.net/navigating-cancer-care/diagnosing-cancer/tests-and-procedures/tumor-marker-tests)).
 
-Implementation note: The data value for TumorMarkerTest has cardinality is 0..1 (required if known) because when the test result is indeterminate, no quantitative data value will be reported. Instead, the reason for the null value will be reported in the DataAbsentReason field."
+Implementation note: The data value for TumorMarker has cardinality is 0..1 (required if known) because when the test result is indeterminate, no quantitative data value will be reported. Instead, the reason for the null value will be reported in the DataAbsentReason field."
 * status, code, subject, effective[x], valueCodeableConcept MS
 * bodySite 0..0
 * referenceRange 0..1

--- a/CancerGenomicsExamples.fsh
+++ b/CancerGenomicsExamples.fsh
@@ -21,6 +21,7 @@ InstanceOf: CancerGenomicsReport
 * status = #final "Final"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
+* specimen = Reference(mCODEGeneticSpecimenExample01)
 * issued = "2019-04-01T11:45:33+11:00"
 * result[CancerGeneticVariant] = Reference(mCODECancerGeneticVariantExample01)
 * result[GenomicRegionStudied] = Reference(mCODEGenomicRegionStudiedExample01)
@@ -35,3 +36,24 @@ InstanceOf: GenomicRegionStudied
 // Commented out -- causes SUSHI to not create this example -- see issue https://github.com/FHIR/sushi/issues/112
 //* component[GeneStudied].valueCodeableConcept = HGNC#619728 "STK11" 
 
+Instance: mCODETumorMarkerExample01 
+InstanceOf: TumorMarker
+* id = "mCODETumorMarkerExample01"
+* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/TumorMarker"
+* status = #final "final"
+* code = LNC#39004-7 "Epidermal growth factor receptor Ag [Presence] in Tissue"
+* subject = Reference(mCODEPatientExample01)
+* effectiveDateTime = "2019-04-01"
+* performer = Reference(mCODEPractitionerExample01) 
+* valueCodeableConcept = SCT#10828004 "Positive (qualifier value)"
+
+Instance: mCODEGeneticSpecimenExample01 
+InstanceOf: GeneticSpecimen
+* id = "mCODEGeneticSpecimenExample01"
+* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/GeneticSpecimen"
+* status = #available "	Available"
+* subject = Reference(mCODEPatientExample01)
+* processing.timeDateTime = "2019-03-20"
+* collection.collector = Reference(mCODEPractitionerExample01) 
+* type = SPTY#TISS "Tissue"
+* collection.bodySite.coding = SCT#41224006 "Structure of lower lobe of left lung (body structure)"

--- a/CancerGenomicsExamples.fsh
+++ b/CancerGenomicsExamples.fsh
@@ -21,9 +21,9 @@ InstanceOf: CancerGenomicsReport
 * status = #final "Final"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
-* specimen = Reference(mCODEGeneticSpecimenExample01)
+* specimen = Reference(Specimen/mCODEGeneticSpecimenExample01)
 * issued = "2019-04-01T11:45:33+11:00"
-* result[CancerGeneticVariant] = Reference(mCODECancerGeneticVariantExample01)
+* result[CancerGeneticVariant] = Reference(Observation/mCODECancerGeneticVariantExample01)
 * result[GenomicRegionStudied] = Reference(mCODEGenomicRegionStudiedExample01)
 
 Instance: mCODEGenomicRegionStudiedExample01
@@ -51,9 +51,9 @@ Instance: mCODEGeneticSpecimenExample01
 InstanceOf: GeneticSpecimen
 * id = "mCODEGeneticSpecimenExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/GeneticSpecimen"
-* status = #available "	Available"
+* status = #available "Available"
 * subject = Reference(mCODEPatientExample01)
 * processing.timeDateTime = "2019-03-20"
 * collection.collector = Reference(mCODEPractitionerExample01) 
 * type = SPTY#TISS "Tissue"
-* collection.bodySite.coding = SCT#41224006 "Structure of lower lobe of left lung (body structure)"
+* collection.bodySite = SCT#41224006 "Structure of lower lobe of left lung (body structure)"

--- a/build/input/ImplementationGuide-fhir.us.mcode.json
+++ b/build/input/ImplementationGuide-fhir.us.mcode.json
@@ -408,6 +408,13 @@
         },
         {
           "reference": {
+            "reference": "Specimen/mCODEGeneticSpecimenExample01"
+          },
+          "name": "Specimen-mCODEGeneticSpecimenExample01",
+          "exampleCanonical": "http://hl7.org/fhir/us/mcode/StructureDefinition/GeneticSpecimen"
+        },
+        {
+          "reference": {
             "reference": "DiagnosticReport/mCODECancerGenomicsReportExample01"
           },
           "name": "DiagnosticReport-mCODECancerGenomicsReportExample01",


### PR DESCRIPTION
TumorMarkerExample01 has a validation error related to missing "Category" however this is a known issue in SUSHI so we'll overlook these errors until a fix is available.