### PR TITLE
Add SUSHI CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,16 @@
+name: SUSHI CI
+
+on: [push]
+
+jobs:
+  test:
+    name: Test using latest SUSHI w/ Node 12.x on Ubuntu linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: npm install -D fsh-sushi
+    - run: npx sushi -v
+    - run: npx sushi .


### PR DESCRIPTION
This adds a GitHub Action workflow to run SUSHI whenever commits are pushed.  If desired, this project can be configured to require that SUSHI CI pass before a branch can be merged.

Currently, SUSHI 0.8.0 always exits with success (exit code `0`) -- so a "successful" SUSHI CI _doesn't_ mean there are no errors.  The next version of SUSHI (0.9.0) will exit with an error (exit code `1`) if there are any errors reported by SUSHI -- which will work better for this CI.

The CI always uses the latest _released_ version of SUSHI, so you'll get these updates automatically.

_NOTE: This only runs Node 12 on Ubuntu linux.  It is optimized for speed.  In theory, the OS or Node version should not matter, so I think this is ok.  The SUSHI app itself is tested on Node 8, 10, and 12 on Ubuntu, Mac, and Windows._