### PR TITLE
Use new extension syntax

### DIFF
--- a/CancerCondition.fsh
+++ b/CancerCondition.fsh
@@ -12,11 +12,11 @@ Description:  "Abstract parent class for describing a primary or secondary metas
 */
 * ^abstract = true
 * extension contains
-    AssertedDate named AssertedDate 0..1 and
-    HistologyMorphologyBehavior named HistologyMorphologyBehavior 0..1
+    AssertedDate named assertedDate 0..1 and
+    HistologyMorphologyBehavior named histologyMorphologyBehavior 0..1
 * bodySite.extension contains
-    Laterality named Laterality 0..1
-* extension[AssertedDate], extension[HistologyMorphologyBehavior], bodySite, bodySite.extension[Laterality] MS
+    Laterality named laterality 0..1
+* extension[assertedDate], extension[histologyMorphologyBehavior], bodySite, bodySite.extension[laterality] MS
 * category = SCT#64572001 "Disease"
 * severity 0..0
 * bodySite from CancerBodyLocationVS (preferred)
@@ -45,7 +45,7 @@ Description: "Records the history of secondary neoplasms, including location(s) 
 Conformance note: For the code attribute, to be compliant with US Core Profiles, SNOMED CT must be used unless there is no suitable code, in which case ICD-10-CM can be used."
 * ^abstract = false
 * extension contains
-    RelatedPrimaryCancerCondition named RelatedPrimaryCancerCondition 0..1
+    RelatedPrimaryCancerCondition named relatedPrimaryCancerCondition 0..1
 * code from SecondaryCancerDisorderVS
 * stage 0..0
 
@@ -76,7 +76,7 @@ Description:  "A comorbidity refers to one or more diseases or conditions that o
 * code from ComorbidConditionVS
 * bodySite from http://hl7.org/fhir/ValueSet/body-site (preferred)
 * bodySite.extension contains
-    Laterality named Laterality 0..1
+    Laterality named laterality 0..1
 * subject only Reference(USCorePatient)
 
 

--- a/CancerCondition.fsh
+++ b/CancerCondition.fsh
@@ -11,11 +11,11 @@ Description:  "Abstract parent class for describing a primary or secondary metas
 3) Laterality should be 0..1, not 0..*
 */
 * ^abstract = true
-* extension contains 
-    AssertedDate 0..1 and 
-    HistologyMorphologyBehavior 0..1
-* bodySite.extension contains 
-    Laterality 0..1
+* extension contains
+    AssertedDate named AssertedDate 0..1 and
+    HistologyMorphologyBehavior named HistologyMorphologyBehavior 0..1
+* bodySite.extension contains
+    Laterality named Laterality 0..1
 * extension[AssertedDate], extension[HistologyMorphologyBehavior], bodySite, bodySite.extension[Laterality] MS
 * category = SCT#64572001 "Disease"
 * severity 0..0
@@ -44,8 +44,8 @@ Description: "Records the history of secondary neoplasms, including location(s) 
 
 Conformance note: For the code attribute, to be compliant with US Core Profiles, SNOMED CT must be used unless there is no suitable code, in which case ICD-10-CM can be used."
 * ^abstract = false
-* extension contains 
-    RelatedPrimaryCancerCondition 0..1
+* extension contains
+    RelatedPrimaryCancerCondition named RelatedPrimaryCancerCondition 0..1
 * code from SecondaryCancerDisorderVS
 * stage 0..0
 
@@ -76,7 +76,7 @@ Description:  "A comorbidity refers to one or more diseases or conditions that o
 * code from ComorbidConditionVS
 * bodySite from http://hl7.org/fhir/ValueSet/body-site (preferred)
 * bodySite.extension contains
-    Laterality 0..1
+    Laterality named Laterality 0..1
 * subject only Reference(USCorePatient)
 
 
@@ -96,7 +96,7 @@ Description: "The presence of an abnormal mass of tissue (neoplasm) that results
 
 Conformance note: For the HistologyMorphologyBehavior attribute, to be compliant with US Core Profiles, SNOMED CT must be used unless there is no suitable code, in which case ICD-O-3 can be used."
 * ^abstract = false
-* extension contains 
+* extension contains
     RelatedPrimaryCancerCondition 0..1 and
     IsPrimaryTumor 0..1
 * IsPrimaryTumor ^short = "Whether the tumor is the original or first tumor in the body, for a particular cancer."

--- a/CancerDiseaseStatus.fsh
+++ b/CancerDiseaseStatus.fsh
@@ -5,7 +5,7 @@ Title:    "Cancer Disease Status"
 Description:    "A clinician's qualitative judgment on the current trend of the cancer, e.g., whether it is stable, worsening (progressing), or improving (responding). The judgment may be based a single type or multiple kinds of evidence, such as imaging data, assessment of symptoms, tumor markers, laboratory data, etc.
 
 Note: The LOINC code chosen to represent this observation (LOINC 88040-1, Response to cancer treatment) does not precisely match the meaning of this profile, but it is the closest available LOINC code at the present time. It is acknowledged that the disease status is different than the status of the disease due to treatment, although in the context of an oncologist visit, disease status can mean response to treatment for patients under their care. However, the LOINC code 88041-2 is more granular than the definition of the profile because cancer disease status is observable regardless of whether the patient is under treatment. The plan is to request a new LOINC code that represents cancer disease status, as it is defined here, and replace the current LOINC code with the new code before normative publication of mCODE."
-* extension contains EvidenceType 0..*
+* extension contains EvidenceType named EvidenceType 0..*
 * extension[EvidenceType].valueCodeableConcept from CancerDiseaseStatusEvidenceTypeVS (required)
 * status, code, subject, effective[x], valueCodeableConcept MS
 * bodySite 0..0

--- a/CancerDiseaseStatus.fsh
+++ b/CancerDiseaseStatus.fsh
@@ -5,8 +5,8 @@ Title:    "Cancer Disease Status"
 Description:    "A clinician's qualitative judgment on the current trend of the cancer, e.g., whether it is stable, worsening (progressing), or improving (responding). The judgment may be based a single type or multiple kinds of evidence, such as imaging data, assessment of symptoms, tumor markers, laboratory data, etc.
 
 Note: The LOINC code chosen to represent this observation (LOINC 88040-1, Response to cancer treatment) does not precisely match the meaning of this profile, but it is the closest available LOINC code at the present time. It is acknowledged that the disease status is different than the status of the disease due to treatment, although in the context of an oncologist visit, disease status can mean response to treatment for patients under their care. However, the LOINC code 88041-2 is more granular than the definition of the profile because cancer disease status is observable regardless of whether the patient is under treatment. The plan is to request a new LOINC code that represents cancer disease status, as it is defined here, and replace the current LOINC code with the new code before normative publication of mCODE."
-* extension contains EvidenceType named EvidenceType 0..*
-* extension[EvidenceType].valueCodeableConcept from CancerDiseaseStatusEvidenceTypeVS (required)
+* extension contains EvidenceType named evidenceType 0..*
+* extension[evidenceType].valueCodeableConcept from CancerDiseaseStatusEvidenceTypeVS (required)
 * status, code, subject, effective[x], valueCodeableConcept MS
 * bodySite 0..0
 * specimen 0..0

--- a/CancerGenomics.fsh
+++ b/CancerGenomics.fsh
@@ -21,7 +21,7 @@ Description:    "Records an alteration in the most common DNA nucleotide sequenc
 */
 * code = LNC#69548-6 "Genetic variant assessment"
 * method from http://loinc.org/vs/LL4048-6 (extensible)
-* specimen only Reference(GeneticSpecimen) 
+* specimen only Reference(GeneticSpecimen)
 * value[x] only CodeableConcept
 * value[x] ^definition = "The overall result of the genetic test; specifically, whether a variant is present, absent, no call, or indeterminant."
 * valueCodeableConcept from http://loinc.org/vs/LL1971-2 (required)
@@ -37,7 +37,7 @@ Description:    "Records an alteration in the most common DNA nucleotide sequenc
     AminoAcidChange 0..1 MS and
     AminoAcidChangeType 0..1 MS and
     CytogeneticLocation 0..* MS and
-    CytogeneticNomenclature 0..1 MS 
+    CytogeneticNomenclature 0..1 MS
 * component[GeneStudied] ^short = "Gene studied [ID]"
 * component[GeneStudied] ^definition = "A gene targeted for mutation analysis, identified in HUGO Gene Nomenclature Committee (HGNC) notation. The required code is HGNC gene ID. Gene IDs are of the format HGNC:n, where n is a unique number. Only the number, n, should be given as the code. For example, the HGNC identifier for the EGFR gene is 3236. The display text associated with the code should be the HGNC official gene symbol. For example, the official gene symbol for epidermal growth factor receptor is EGFR."
 * component[GeneStudied].code = LNC#48018-6
@@ -77,7 +77,7 @@ Description:    "Records an alteration in the most common DNA nucleotide sequenc
 * component[CytogeneticLocation] ^short = "Cytogenetic (chromosome) location"
 * component[CytogeneticLocation] ^definition = "The cytogenetic (chromosome) location."
 * component[CytogeneticLocation].code = LNC#48001-2
-* component[CytogeneticLocation].value[x] 1..1 
+* component[CytogeneticLocation].value[x] 1..1
 // CG Reporting IG does not constrain the CytogeneticLocation value type.
 * component[CytogeneticNomenclature] ^short = "Variant ISCN"
 * component[CytogeneticNomenclature] ^definition = "The cytogenetic (chromosome) location, represented using the International System for Human Cytogenetic Nomenclature (ISCN)"
@@ -117,9 +117,9 @@ Title:      "Genetic Specimen"
 Description:    "A small sample of blood, hair, skin, amniotic fluid (the fluid that surrounds a fetus during pregnancy), or other tissue which is excised from a subject for the purposes of genomics testing or analysis."
 * type 1..1 MS
 * type from GeneticSpecimenTypeVS
-* collection.bodySite.extension contains 
-    Laterality 0..1
-* collection.bodySite, collection.bodySite.extension[Laterality] MS 
+* collection.bodySite.extension contains
+    Laterality named Laterality 0..1
+* collection.bodySite, collection.bodySite.extension[Laterality] MS
 
 
 Profile:    CancerGenomicsReport

--- a/CancerGenomics.fsh
+++ b/CancerGenomics.fsh
@@ -118,8 +118,8 @@ Description:    "A small sample of blood, hair, skin, amniotic fluid (the fluid 
 * type 1..1 MS
 * type from GeneticSpecimenTypeVS
 * collection.bodySite.extension contains
-    Laterality named Laterality 0..1
-* collection.bodySite, collection.bodySite.extension[Laterality] MS
+    Laterality named laterality 0..1
+* collection.bodySite, collection.bodySite.extension[laterality] MS
 
 
 Profile:    CancerGenomicsReport

--- a/CancerRelatedMedicationStatement.fsh
+++ b/CancerRelatedMedicationStatement.fsh
@@ -14,8 +14,8 @@ Description:    "A record of the use of a medication (individual administration 
 */
 * effective[x], medication[x] MS
 * extension contains
-    TreatmentIntent named TreatmentIntent 0..1 MS and
-    TerminationReason named TerminationReason 0..* MS
+    TreatmentIntent named treatmentIntent 0..1 MS and
+    TerminationReason named terminationReason 0..* MS
 //* reasonReference only Reference(PrimaryCancerCondition | SecondaryCancerCondition | Observation | DiagnosticReport | ComorbidCondition)
 * effective[x] 1..1  // change from 0..1 to 1..1
 * reasonCode 0..1

--- a/CancerRelatedMedicationStatement.fsh
+++ b/CancerRelatedMedicationStatement.fsh
@@ -12,12 +12,12 @@ Description:    "A record of the use of a medication (individual administration 
 6) informationSource is missing PractitionerRole
 7) not sure why reasonCode has be changed from 0..* to 0..1
 */
-* effective[x], medication[x] MS 
-* extension contains 
-    TreatmentIntent 0..1 MS and 
-    TerminationReason 0..* MS 
+* effective[x], medication[x] MS
+* extension contains
+    TreatmentIntent named TreatmentIntent 0..1 MS and
+    TerminationReason named TerminationReason 0..* MS
 //* reasonReference only Reference(PrimaryCancerCondition | SecondaryCancerCondition | Observation | DiagnosticReport | ComorbidCondition)
 * effective[x] 1..1  // change from 0..1 to 1..1
-* reasonCode 0..1 
+* reasonCode 0..1
 * dosage 0..1
 * medicationCodeableConcept from http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible)

--- a/CancerRelatedProcedures.fsh
+++ b/CancerRelatedProcedures.fsh
@@ -19,8 +19,8 @@ Conformance note: If an ICD-10-PCS code is used in the code attribute, and there
 11) report should allow Reference(DiagnosticReport | DocumentReference | Composition) -- currently mCODE constrains to DiagnosticReport only.
 */
 * extension contains
-    TreatmentIntent named TreatmentIntent 0..1 and
-    TerminationReason named TerminationReason 0..*
+    TreatmentIntent named treatmentIntent 0..1 and
+    TerminationReason named terminationReason 0..*
 * partOf only Reference(Procedure)
 * category = SCT#53438000 "Radiation therapy procedure or service (procedure)"
 * code from RadiationProcedureVS (extensible)
@@ -31,9 +31,9 @@ Conformance note: If an ICD-10-PCS code is used in the code attribute, and there
 * reasonReference only Reference(CancerConditionParent)
 * bodySite from RadiationTargetBodySiteVS (extensible)
 * bodySite.extension contains
-    Laterality named Laterality 0..1
+    Laterality named laterality 0..1
 * focalDevice 0..0
-* bodySite, bodySite.extension[Laterality], extension[TreatmentIntent] MS
+* bodySite, bodySite.extension[laterality], extension[treatmentIntent] MS
 
 
 Profile:  CancerRelatedSurgicalProcedure
@@ -43,7 +43,7 @@ Title:    "Cancer-Related Surgical Procedure"
 Description: "A surgical action addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the ReasonReference and ReasonCode to cancer conditions. Conformance note: If an ICD-10-PCS code is used in the code attribute, and there is a semantically equivalent SNOMED CT or CPT code, the resulting Procedure instance will not be compliant with US Core Profiles."
 * code from CancerRelatedSurgicalProcedureVS (extensible)
 * extension contains
-    TreatmentIntent named TreatmentIntent 0..1
+    TreatmentIntent named treatmentIntent 0..1
 * subject only Reference(CancerPatient)
 * category = SCT#387713003 "Surgical procedure"
 * reasonCode from CancerDisorderVS (extensible)
@@ -52,8 +52,8 @@ Description: "A surgical action addressing a cancer condition. The scope of this
 * recorder only Reference(Practitioner | PractitionerRole)
 * performer.actor only Reference(Practitioner | PractitionerRole | Organization)
 * bodySite.extension contains
-    Laterality named Laterality 0..1
-* reasonCode, reasonReference, extension[TreatmentIntent], bodySite, bodySite.extension[Laterality] MS  // other MS will be inherited from USCoreProcedure
+    Laterality named laterality 0..1
+* reasonCode, reasonReference, extension[treatmentIntent], bodySite, bodySite.extension[laterality] MS  // other MS will be inherited from USCoreProcedure
 
     /* Save for possible later use
 

--- a/CancerRelatedProcedures.fsh
+++ b/CancerRelatedProcedures.fsh
@@ -2,7 +2,7 @@ Profile:  CancerRelatedRadiationProcedure
 Parent:   USCoreProcedure
 Id:       mcode-cancer-related-radiation-procedure
 Title:    "Cancer-Related Radiation Procedure"
-Description: "A radiological treatment addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the ReasonReference and ReasonCode to cancer conditions. 
+Description: "A radiological treatment addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the ReasonReference and ReasonCode to cancer conditions.
 
 Conformance note: If an ICD-10-PCS code is used in the code attribute, and there is a semantically equivalent SNOMED CT or CPT code, the resulting Procedure instance will not be compliant with [US Core Profiles](http://hl7.org/fhir/us/core/index.html)"
 /* Issues relative to mCODE 0.9.x
@@ -18,9 +18,9 @@ Conformance note: If an ICD-10-PCS code is used in the code attribute, and there
 10) Encounter should not be constrained to US Core Encounter -- US Core doesn't have this constraint
 11) report should allow Reference(DiagnosticReport | DocumentReference | Composition) -- currently mCODE constrains to DiagnosticReport only.
 */
-* extension contains 
-    TreatmentIntent 0..1 and 
-    TerminationReason 0..*
+* extension contains
+    TreatmentIntent named TreatmentIntent 0..1 and
+    TerminationReason named TerminationReason 0..*
 * partOf only Reference(Procedure)
 * category = SCT#53438000 "Radiation therapy procedure or service (procedure)"
 * code from RadiationProcedureVS (extensible)
@@ -31,9 +31,9 @@ Conformance note: If an ICD-10-PCS code is used in the code attribute, and there
 * reasonReference only Reference(CancerConditionParent)
 * bodySite from RadiationTargetBodySiteVS (extensible)
 * bodySite.extension contains
-    Laterality 0..1
+    Laterality named Laterality 0..1
 * focalDevice 0..0
-* bodySite, bodySite.extension[Laterality], extension[TreatmentIntent] MS    
+* bodySite, bodySite.extension[Laterality], extension[TreatmentIntent] MS
 
 
 Profile:  CancerRelatedSurgicalProcedure
@@ -42,8 +42,8 @@ Id:       mcode-cancer-related-surgical-procedure
 Title:    "Cancer-Related Surgical Procedure"
 Description: "A surgical action addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the ReasonReference and ReasonCode to cancer conditions. Conformance note: If an ICD-10-PCS code is used in the code attribute, and there is a semantically equivalent SNOMED CT or CPT code, the resulting Procedure instance will not be compliant with US Core Profiles."
 * code from CancerRelatedSurgicalProcedureVS (extensible)
-* extension contains 
-    TreatmentIntent 0..1
+* extension contains
+    TreatmentIntent named TreatmentIntent 0..1
 * subject only Reference(CancerPatient)
 * category = SCT#387713003 "Surgical procedure"
 * reasonCode from CancerDisorderVS (extensible)
@@ -52,7 +52,7 @@ Description: "A surgical action addressing a cancer condition. The scope of this
 * recorder only Reference(Practitioner | PractitionerRole)
 * performer.actor only Reference(Practitioner | PractitionerRole | Organization)
 * bodySite.extension contains
-    Laterality 0..1
+    Laterality named Laterality 0..1
 * reasonCode, reasonReference, extension[TreatmentIntent], bodySite, bodySite.extension[Laterality] MS  // other MS will be inherited from USCoreProcedure
 
     /* Save for possible later use
@@ -62,7 +62,7 @@ Id: mcode-radiation-dose
 Title:  "Radiation Dose"
 Description: "Information related to the dose of radiation received in a RadiationProcedure, including the dose per fraction, the number of fractions delivered, and the total radiation dose delivered."
 * value[x] 0..0
-* extension contains 
+* extension contains
     RadiationDosePerFraction 0..1 and
     RadiationFractionsDelivered 0..1 and
     TotalRadiationDoseDelivered 0..1

--- a/Examples.fsh
+++ b/Examples.fsh
@@ -6,9 +6,9 @@ Description: "mCODE Example for Primary Cancer Condition"
 * clinicalStatus = ClinStatus#active "Active"
 * verificationStatus = VerStatus#confirmed "Confirmed"
 * code = SCT#254637007 "Non-small cell lung cancer (disorder)"
-* extension[HistologyMorphologyBehavior].valueCodeableConcept = SCT#35917007 "Adenocarcinoma"
+* extension[histologyMorphologyBehavior].valueCodeableConcept = SCT#35917007 "Adenocarcinoma"
 * bodySite = SCT#39607008 "Lung structure (body structure)"
-* bodySite.extension[Laterality].valueCodeableConcept = SCT#7771000 "Left (qualifier value)"
+* bodySite.extension[laterality].valueCodeableConcept = SCT#7771000 "Left (qualifier value)"
 * subject = Reference(mCODEPatientExample01)
 * onsetDateTime = "2019-04-01"
 * asserter = Reference(mCODEPractitionerExample01)
@@ -20,7 +20,7 @@ InstanceOf: SecondaryCancerCondition
 Description: "mCODE Example for Secondary Cancer Condition"
 * id = "mCODESecondaryCancerConditionExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-secondary-cancer-condition"
-* extension[RelatedPrimaryCancerCondition].valueReference = Reference(mCODEPrimaryCancerConditionExample01)
+* extension[relatedPrimaryCancerCondition].valueReference = Reference(mCODEPrimaryCancerConditionExample01)
 * clinicalStatus = ClinStatus#active "Active"
 * verificationStatus = VerStatus#confirmed "Confirmed"
 * code = SCT#94225005 "Secondary malignant neoplasm of brain"
@@ -33,8 +33,8 @@ InstanceOf: CancerDiseaseStatus
 Description: "mCODE Example for Cancer Disease Status"
 * id = "mCODECancerDiseaseStatusExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
-//* extension[EvidenceType].url = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type"
-* extension[EvidenceType].valueCodeableConcept = SCT#252416005 "Histopathology test (procedure)"
+//* extension[evidenceType].url = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type"
+* extension[evidenceType].valueCodeableConcept = SCT#252416005 "Histopathology test (procedure)"
 * status = #final "final"
 * category = ObsCat#laboratory "laboratory"
 * subject = Reference(mCODEPatientExample01)
@@ -69,7 +69,7 @@ Description: "mCODE Example for Patient"
 * name.given[1] = "B."
 * contact.telecom[0].system = #phone
 * contact.telecom[0].value = "555-555-5555"
-* contact.telecom[0].use = #home 
+* contact.telecom[0].use = #home
 * contact.telecom[1].system = #email
 * contact.telecom[1].value = "john.anyperson@example.com"
 * gender = #male
@@ -102,7 +102,7 @@ Description: "mCODE Example for Patient"
 * name.given[1] = "A."
 * contact.telecom[0].system = #phone
 * contact.telecom[0].value = "999-999-9999"
-* contact.telecom[0].use = #home 
+* contact.telecom[0].use = #home
 * contact.telecom[1].system = #email
 * contact.telecom[1].value = "eve.anyperson@example.com"
 * gender = #female
@@ -148,17 +148,17 @@ Description: "mCODE Example for Practitioner"
 * qualification.code = http://terminology.hl7.org/CodeSystem/v2-0360|2.7#MD "Doctor of Medicine"
 
 
-Instance: mCODEECOGPerformanceStatusExample01 
+Instance: mCODEECOGPerformanceStatusExample01
 InstanceOf: ECOGPerformanceStatus
 Description: "mCODE Example for ECOG Performance Status"
 * id = "mCODEECOGPerformanceStatusExample01"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-ecog-performance-status" 
+* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-ecog-performance-status"
 * status = #final "final"
 * category = ObsCat#survey "survey"
 * method = SCT#5880005 "Clinical examination"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
-* performer = Reference(mCODEPractitionerExample01) 
+* performer = Reference(mCODEPractitionerExample01)
 * valueInteger = 0
 * interpretation = LNC#LA9622-7 "Fully active, able to carry on all pre-disease performance without restriction"
 
@@ -187,7 +187,7 @@ Description: "mCODE Example for Cancer Related Medication Statement"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * dateAsserted = "2019-04-01"
-* extension[TreatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
+* extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
 * dosage.text = "250mg orally once daily with or without food"
 * dosage.route = SCT#26643006 "Oral use"
 * dosage.doseAndRate.doseQuantity.value = 250.0
@@ -204,8 +204,8 @@ Description: "mCODE Example for Cancer Related Medication Statement"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * dateAsserted = "2019-04-01"
-* extension[TreatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
-* extension[TerminationReason].valueCodeableConcept = SCT#182992009 "Treatment completed (situation)"
+* extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
+* extension[terminationReason].valueCodeableConcept = SCT#182992009 "Treatment completed (situation)"
 * dosage.text = "250mg orally once daily with or without food"
 * dosage.route = SCT#26643006 "Oral use"
 * dosage.doseAndRate.doseQuantity.value = 250.0
@@ -221,22 +221,22 @@ Description: "mCODE Example for Cancer Related Surgical Procedure"
 * subject = Reference(mCODEPatientExample01)
 * asserter = Reference(mCODEPractitionerExample01)
 * performedDateTime = "2019-03-01"
-* extension[TreatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
+* extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
 * reasonReference = Reference(mCODEPrimaryCancerConditionExample01)
 * bodySite = SCT#41224006 "Structure of lower lobe of left lung (body structure)"
 
 Instance: mCODECancerRelatedRadiationProcedureExample01
-InstanceOf: CancerRelatedRadiationProcedure 
+InstanceOf: CancerRelatedRadiationProcedure
 Description: "mCODE Example for Cancer Related Radiation Procedure"
 * id = "mCODECancerRelatedRadiationProcedureExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-radiation-procedure"
-* status = #completed "completed" 
+* status = #completed "completed"
 * code = SCT#152198000 "Brachytherapy (procedure)"
 * subject = Reference(mCODEPatientExample01)
 * asserter = Reference(mCODEPractitionerExample01)
 * performedDateTime = "2019-03-01"
-* extension[TreatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
-//* extension[RadiationDose].extension[TotalRadiationDoseDelivered].valueQuantity = UCUM#cGy 
+* extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent"
+//* extension[RadiationDose].extension[TotalRadiationDoseDelivered].valueQuantity = UCUM#cGy
 //* extension[RadiationDose].extension[TotalRadiationDoseDelivered].valueQuantity.value = 1200.0
 * reasonReference = Reference(mCODEPrimaryCancerConditionExample01)
 * bodySite = SCT#41224006 "Structure of lower lobe of left lung (body structure)"
@@ -246,9 +246,9 @@ InstanceOf: TNMClinicalStageGroup
 Description: "mCODE Example for TNM Clinical Stage Group"
 * id = "mCODETNMClinicalStageGroupExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#survey "Survey"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#3C "IIIC"
@@ -261,9 +261,9 @@ InstanceOf: TNMClinicalDistantMetastasesCategory
 Description: "mCODE Example for TNM Clinical Distant Metastases Category"
 * id = "mCODETNMClinicalDistantMetastasesCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-distant-metastases-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#survey "Survey"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#cM0 "M0"
@@ -273,9 +273,9 @@ InstanceOf: TNMClinicalPrimaryTumorCategory
 Description: "mCODE Example for TNM Clinical Primary Tumor Category"
 * id = "mCODETNMClinicalPrimaryTumorCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-primary-tumor-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#survey "Survey"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#cT3 "T3"
@@ -286,9 +286,9 @@ InstanceOf: TNMClinicalRegionalNodesCategory
 Description: "mCODE Example for TNM Clinical Regional Nodes Category"
 * id = "mCODETNMClinicalRegionalNodesCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-regional-nodes-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#survey "Survey"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#cN3 "N3"
@@ -299,9 +299,9 @@ InstanceOf: TNMPathologicalStageGroup
 Description: "mCODE Example for TNM Pathological Stage Group"
 * id = "mCODETNMPathologicalStageGroupExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-stage-group"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#laboratory "laboratory"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#3C "IIIC"
@@ -315,9 +315,9 @@ InstanceOf: TNMPathologicalDistantMetastasesCategory
 Description: "mCODE Example for TNM Pathological Distant Metastases Category"
 * id = "mCODETNMPathologicalDistantMetastasesCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-distant-metastases-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#laboratory "laboratory"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#pM0 "M0"
@@ -328,9 +328,9 @@ InstanceOf: TNMPathologicalPrimaryTumorCategory
 Description: "mCODE Example for TNM Pathological Primary Tumor Category"
 * id = "mCODETNMPathologicalPrimaryTumorCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-primary-tumor-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#laboratory "laboratory"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#pT3 "T3"
@@ -341,9 +341,9 @@ InstanceOf: TNMPathologicalRegionalNodesCategory
 Description: "mCODE Example for TNM Pathological Regional Nodes Category"
 * id = "mCODETNMPathologicalRegionalNodesCategoryExample01"
 * meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-regional-nodes-category"
-* status = #final "final" 
+* status = #final "final"
 * category = ObsCat#laboratory "laboratory"
-* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition" 
+* method = MTH#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample01)
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = AJCC#pN3 "N3"


### PR DESCRIPTION
The upcoming SUSHI 0.10.0 uses a new syntax for using STANDALONE (as opposed to inline) extensions.  This PR uses the new syntax, but ensures output is the same by using the same slice name as the extension name.

NOTE: Some changes are whitespace-only, as my editor automatically trims whitespace.

Marking as a DRAFT PR so it is not merged until SUSHI 0.10.0 is available.